### PR TITLE
Remove decode("utf-8")

### DIFF
--- a/data.py
+++ b/data.py
@@ -119,7 +119,7 @@ class CocoDataset(data.Dataset):
 
         # Convert caption (string) to word ids.
         tokens = nltk.tokenize.word_tokenize(
-            str(caption).lower().decode('utf-8'))
+            str(caption).lower())
         caption = []
         caption.append(vocab('<start>'))
         caption.extend([vocab(token) for token in tokens])

--- a/data.py
+++ b/data.py
@@ -178,7 +178,7 @@ class FlickrDataset(data.Dataset):
 
         # Convert caption (string) to word ids.
         tokens = nltk.tokenize.word_tokenize(
-            str(caption).lower().decode('utf-8'))
+            str(caption).lower())
         caption = []
         caption.append(vocab('<start>'))
         caption.extend([vocab(token) for token in tokens])


### PR DESCRIPTION
Since strings in Python3 are already decoded, there is no need to decode again.

https://stackoverflow.com/questions/28583565/str-object-has-no-attribute-decode-python-3-error