### PR TITLE
pass enforce_sorted to False

### DIFF
--- a/model.py
+++ b/model.py
@@ -206,7 +206,7 @@ class EncoderText(nn.Module):
         """
         # Embed word ids to vectors
         x = self.embed(x)
-        packed = pack_padded_sequence(x, lengths, batch_first=True)
+        packed = pack_padded_sequence(x, lengths, batch_first=True, enforce_sorted=True)
 
         # Forward propagate RNN
         out, _ = self.rnn(packed)


### PR DESCRIPTION
This is a PR as much as it is a question, according to the documentation on `pack_padded_sequence`, by default it understands that their input comes sorted from longest sentence to shortest.

```python
        enforce_sorted (bool, optional): if ``True``, the input is expected to
            contain sequences sorted by length in a decreasing order. If
            ``False``, the input will get sorted unconditionally. Default: ``True``.
```

I cannot see where is this guaranteed at data loading time to ensure that every batch is properly processed, could this be an issue? I have reproduced your results, but I have seen differences when embedding sentences alone or in a batch, and what I have observed is that embeddings in a batch seemed to be mixed up.